### PR TITLE
run as `trusted: true`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ sandbox
 coverage
 package-lock.json
 corestores/
+assets/
 by-dkey/
 current
 lock

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ sandbox.js
 sandbox
 coverage
 package-lock.json
+corestores/
+by-dkey/
+current
+lock

--- a/example/pear-desktop.js
+++ b/example/pear-desktop.js
@@ -5,5 +5,5 @@ console.log('Bootstrapping...')
 bootstrap({
   pearKey: hypercoreid.decode('dhpc5npmqkansx38uh18h3uwpdp6g9ukozrqyc4irbhwriedyeho'),
   pearDir: __dirname,
-  appLink: 'pear://rbw6fbxorqgjgyitworh3f73utc5cu7sczhptn64oonbznuojiao'
+  appLink: 'pear://rbw6fbxorqgjgyitworh3f73utc5cu7sczhptn64oonbznuojiao' // pear://runtime
 })

--- a/example/runtime.js
+++ b/example/runtime.js
@@ -1,9 +1,9 @@
-const { decode } = require('hypercore-id-encoding')
+const hypercoreid = require('hypercore-id-encoding')
 const bootstrap = require('..')
 
 console.log('Bootstrapping...')
 bootstrap({
-  pearKey: decode('pqbzjhqyonxprx8hghxexnmctw75mr91ewqw5dxe1zmntfyaddqy'), // production build
+  pearKey: hypercoreid.decode('pqbzjhqyonxprx8hghxexnmctw75mr91ewqw5dxe1zmntfyaddqy'), // production build
   pearDir: __dirname,
   appLink: 'pear://runtime'
 })

--- a/example/runtime.js
+++ b/example/runtime.js
@@ -1,0 +1,9 @@
+const { decode } = require('hypercore-id-encoding')
+const bootstrap = require('..')
+
+console.log('Bootstrapping...')
+bootstrap({
+  pearKey: decode('pqbzjhqyonxprx8hghxexnmctw75mr91ewqw5dxe1zmntfyaddqy'), // production build
+  pearDir: __dirname,
+  appLink: 'pear://runtime'
+})

--- a/example/runtime.js
+++ b/example/runtime.js
@@ -3,7 +3,7 @@ const bootstrap = require('..')
 
 console.log('Bootstrapping...')
 bootstrap({
-  pearKey: hypercoreid.decode('pqbzjhqyonxprx8hghxexnmctw75mr91ewqw5dxe1zmntfyaddqy'), // production build
+  pearKey: hypercoreid.decode('dhpc5npmqkansx38uh18h3uwpdp6g9ukozrqyc4irbhwriedyeho'),
   pearDir: __dirname,
-  appLink: 'pear://runtime'
+  appLink: 'pear://rbw6fbxorqgjgyitworh3f73utc5cu7sczhptn64oonbznuojiao'
 })

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ async function bootstrap (opts = {}) {
 
   })
   await ipc.ready()
-  const stream = ipc.run({ link: appLink, flags: { preflight: true } })
+  const stream = ipc.run({ link: appLink, flags: { preflight: true, trusted: true } })
   const result = await opwait(stream, onstatus)
   await ipc.close()
   const bail = result?.bail ?? ERR_INTERNAL_ERROR('Expected PREFLIGHT bail')


### PR DESCRIPTION
* `ipc.run { preflight: true, trusted: true } `

---

* Added example for quick standalone test:

```
$ bare examples/pear-desktop.js
# syncs pear-next + pear://runtime's assets (expected prod key)
```
